### PR TITLE
avoid collision with coldfront allocation url

### DIFF
--- a/src/coldfront_plugin_api/urls.py
+++ b/src/coldfront_plugin_api/urls.py
@@ -23,6 +23,6 @@ class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 router = routers.SimpleRouter()
-router.register(r'allocations', AllocationViewSet)
+router.register(r'allocations', AllocationViewSet, basename='api-allocation')
 
 urlpatterns = router.urls


### PR DESCRIPTION
The Django REST framework router autogenerates URL names based on the queryset if no basename is specified. In the case of allocations, this results in `allocation-list` and `allocation-detail` url names being generated which conflicts with the upstream allocation urls/view names. Adding an explicit basename fixes this by using a different prefix