### PR TITLE
Fix wrong env var check for OIDC

### DIFF
--- a/src/coldfront_plugin_api/urls.py
+++ b/src/coldfront_plugin_api/urls.py
@@ -9,8 +9,8 @@ from coldfront.core.allocation.models import Allocation
 
 from coldfront_plugin_api import serializers
 
-if os.getenv('PLUGIN_OIDC') == 'True':
-    AUTHENTICATION_CLASSES = [OIDCAuthentication]
+if os.getenv('PLUGIN_AUTH_OIDC') == 'True':
+    AUTHENTICATION_CLASSES = [OIDCAuthentication, SessionAuthentication]
 else:
     AUTHENTICATION_CLASSES = [SessionAuthentication, BasicAuthentication]
 

--- a/src/local_settings.py
+++ b/src/local_settings.py
@@ -16,7 +16,7 @@ REST_FRAMEWORK = {
     ],
 }
 
-if os.getenv('PLUGIN_OIDC') == 'True':
+if os.getenv('PLUGIN_AUTH_OIDC') == 'True':
     REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'].append(
         'mozilla_django_oidc.contrib.drf.OIDCAuthentication',
     )


### PR DESCRIPTION
The plugin expects `PLUGIN_OIDC` for OpenID Connect when it should be `PLUGIN_AUTH_OIDC`.

https://github.com/nerc-project/coldfront-nerc/blob/ce387b4b31ccc5e49bb05de87a82a717246a068b/k8s/overlays/prod/configmap.yaml#L10

This causes the plugin to not correctly configure OIDC for authentication of the `/api/allocations/` endpoint and defaults to BasicAuthentication and SessionAuthentication.

Additionally, this keeps SessionAuthentiation because it's useful for browsing the API through a web browser.